### PR TITLE
Add sameSite to cookie and remove session.

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -58,6 +58,7 @@ router.post('/register', async (req, res) => {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			domain: 'https://prompt-builder.netlify.app/',
+			sameSite: 'none',
 		})
 
 		const userToReturn = { ...savedUser._doc }

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,6 @@ import * as dotenv from 'dotenv'
 import cors from 'cors'
 import mongoose from 'mongoose'
 import cookieParser from 'cookie-parser'
-import session from 'express-session'
 
 import authRoute from './routes/auth.js'
 import historyRoute from './routes/history.js'
@@ -27,17 +26,6 @@ app.use('/api/auth', authRoute)
 app.use('/api/history', historyRoute)
 app.use('/api/prompts', promptsRoute)
 app.use('/api/dalle', dalleRoute)
-app.use(
-	session({
-		secret: 'test secret', // change this!
-		resave: true,
-		saveUninitialized: false,
-		cookie: {
-			sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // must be 'none' to enable cross-site delivery
-			secure: process.env.NODE_ENV === 'production', // must be true if sameSite='none'
-		},
-	})
-)
 
 mongoose.set('strictQuery', true)
 


### PR DESCRIPTION
Session apparently is prone to leakage. sameSite may also be a security risk.

Last crack on cross domain cookies as this is a particular pain point apparently when deploying client and server on seperate domains. Seems to be an easy fix to migrate both to Heroku, but giving it another go. Will revisit cross domain with more backend experience.